### PR TITLE
Multi-UAV Recursive Launch Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,8 @@ endif()
 #################################
 
 find_package( Boost COMPONENTS log thread system filesystem container REQUIRED )
-set(NLopt_DIR /home/viciopoli/InstalledLibs/nlopt/lib/cmake/nlopt)
-set(Ceres_DIR /home/viciopoli/InstalledLibs/Ceres/lib/cmake/Ceres)
+set(NLopt_DIR /usr/local/lib/cmake/nlopt)
+set(Ceres_DIR /usr/local/lib/cmake/Ceres)
 
 find_package(x 1.2.3 REQUIRED)
 if(x_FOUND)

--- a/UAV0_params_thermal.yaml
+++ b/UAV0_params_thermal.yaml
@@ -114,7 +114,7 @@ pr_desc_min_distance: 50.0
 desc_type: 0 
  
 # BoW ORB vocabulary
-vocabulary_path: '/home/viciopoli/JPL/devel/x_ws/src/x/Vocabulary/thermal_voc_3_4_dbow3_calib.yaml'
+vocabulary_path: '/home/curtis/projects/jplx_ws/src/x_multi_agent/Vocabulary/thermal_voc_3_4_dbow3_calib.yaml'
 
 sigma_landmark: 0.02 # meters
  

--- a/UAV1_params_thermal.yaml
+++ b/UAV1_params_thermal.yaml
@@ -125,7 +125,7 @@ pr_desc_min_distance: 50.0
 desc_type: 0 # DESCRIPTOR_TYPE { ORB=0, SIFT, SURF };
  
 # BoW ORB vocabulary
-vocabulary_path: '/home/viciopoli/JPL/devel/x_ws/src/x/Vocabulary/thermal_voc_3_4_dbow3_calib.yaml'
+vocabulary_path: '/home/curtis/projects/jplx_ws/src/x_multi_agent/Vocabulary/thermal_voc_3_4_dbow3_calib.yaml'
 
 sigma_landmark: 0.02 # meters
  

--- a/launch/vio_multi_thermal.launch
+++ b/launch/vio_multi_thermal.launch
@@ -37,7 +37,7 @@
   </group>
 
   <!-- recursively start new node -->
-  <include file="$(find x_vio_ros)/launch/vio_thermal.launch" if="$(eval arg('nr') - 1 > 0)">
+  <include file="$(find x_vio_ros)/launch/vio_multi_thermal.launch" if="$(eval arg('nr') - 1 > 0)">
     <arg name="nr" value="$(eval arg('nr') - 1)"/>
   </include>
 

--- a/sed_vocab_replacement.txt
+++ b/sed_vocab_replacement.txt
@@ -1,0 +1,3 @@
+# line for replacing vocabulary path in all yaml files that need it changed
+
+sed -i "s|'/home/viciopoli/JPL/devel/x_ws/src/x/Vocabulary/thermal_voc_3_4_dbow3_calib.yaml'|'/home/curtis/projects/jplx_ws/src/x_multi_agent/Vocabulary/thermal_voc_3_4_dbow3_calib.yaml'|g" *.yaml


### PR DESCRIPTION
This PR fixes the recursive launch of the thermal VIO launch file. In the multi uav launch file, it references the wrong name to recursively launch VIO nodes. This PR fixes that naming change.

Additionally, it sets the NLopt and Ceres directory to /usr/local instead of user space. This was more of a personal preference, but can be easily changed in and out if needed in the CMakeLists.

Lastly, I used the sed command to replace the vocabulary path for DBow3. The path will need to be replaced for each YAML file, so the text file I created is a quick little reference for replacing all yaml files if needed.

Merging this PR to main of my fork of the repo.
